### PR TITLE
added missing feature checks from macOS 12 and 13

### DIFF
--- a/Sources/metalgpu/MetalGpuInfo.swift
+++ b/Sources/metalgpu/MetalGpuInfo.swift
@@ -238,7 +238,9 @@ extension MTLDevice {
                 .macCatalyst2: "MacCatalyst2"
             ]
             
-            if #available(macOS 13.0, *) {families[.metal3] = "Metal3"}
+            if #available(macOS 13.0, *) {
+                families[.metal3] = "Metal3"
+            }
 
             var supportedFamilies: [String] = []
             for (family, text) in families {

--- a/Sources/metalgpu/MetalGpuTool.swift
+++ b/Sources/metalgpu/MetalGpuTool.swift
@@ -103,6 +103,10 @@ struct MetalGpuTool: ParsableCommand {
         if let sparseTileSizeInBytes = info.sparseTileSizeInBytes {
             print("  Sparse Tile Size: \(byteCountString(Int64(sparseTileSizeInBytes)))")
         }
+        
+        if let maxSupportedVertexAmplification = info.maxSupportedVertexAmplification {
+            print("  Max Vertex Amplification: \(maxSupportedVertexAmplification)")
+        }
     }
 
     func joinedOrEmpty(_ items: [String], _ otherwise: String) -> String {


### PR DESCRIPTION
adds:

- GPU Families:
  - Apple8
  - Metal3
- supportsVertexAmplificationCount
- supportsFunctionPointersFromRender
- supportsRaytracingFromRender
